### PR TITLE
Define confluent repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,4 +24,10 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>http://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Upon a clean repository, the build will fail. Defined the confluent repository such as https://docs.confluent.io/3.0.0/installation.html#maven-repository-for-jars